### PR TITLE
upgrade to redisclient/v9

### DIFF
--- a/delayed.go
+++ b/delayed.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-redis/redis/v9"
 	"github.com/kkkbird/quuid"
+	"github.com/redis/go-redis/v9"
 )
 
 const (

--- a/delayed.go
+++ b/delayed.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-redis/redis/v8"
+	"github.com/go-redis/redis/v9"
 	"github.com/kkkbird/quuid"
 )
 
@@ -55,7 +55,7 @@ func (r *QRedisDelayed) AddByDeadline(ctx context.Context, d time.Time, data ...
 		return ErrNoData
 	}
 	score := float64(d.UnixNano())
-	members := make([]*redis.Z, len(data))
+	members := make([]redis.Z, len(data))
 
 	for i, d := range data {
 		// if r.unmarshalType != nil && reflect.TypeOf(data[i]) != r.unmarshalType {
@@ -74,7 +74,7 @@ func (r *QRedisDelayed) AddByDeadline(ctx context.Context, d time.Time, data ...
 			member = string(jstr)
 		}
 		// add uuid to make all member member
-		members[i] = &redis.Z{Score: score, Member: id + ":" + string(member)}
+		members[i] = redis.Z{Score: score, Member: id + ":" + member}
 	}
 	r.db.ZAdd(ctx, r.key, members...)
 

--- a/delayed_test.go
+++ b/delayed_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-redis/redis/v8"
+	"github.com/go-redis/redis/v9"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/suite"
 

--- a/delayed_test.go
+++ b/delayed_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-redis/redis/v9"
+	"github.com/redis/go-redis/v9"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/suite"
 

--- a/example/main.go
+++ b/example/main.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/go-redis/redis/v9"
 	"github.com/kkkbird/qdelayed"
+	"github.com/redis/go-redis/v9"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/example/main.go
+++ b/example/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/go-redis/redis/v8"
+	"github.com/go-redis/redis/v9"
 	"github.com/kkkbird/qdelayed"
 	log "github.com/sirupsen/logrus"
 )

--- a/example2/add/add.go
+++ b/example2/add/add.go
@@ -6,7 +6,7 @@ import (
 
 	"strconv"
 
-	"github.com/go-redis/redis/v8"
+	"github.com/go-redis/redis/v9"
 	"github.com/kkkbird/qdelayed"
 	log "github.com/sirupsen/logrus"
 )

--- a/example2/add/add.go
+++ b/example2/add/add.go
@@ -6,8 +6,8 @@ import (
 
 	"strconv"
 
-	"github.com/go-redis/redis/v9"
 	"github.com/kkkbird/qdelayed"
+	"github.com/redis/go-redis/v9"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/example2/read/read.go
+++ b/example2/read/read.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 
-	"github.com/go-redis/redis/v8"
+	"github.com/go-redis/redis/v9"
 	"github.com/kkkbird/qdelayed"
 	log "github.com/sirupsen/logrus"
 )

--- a/example2/read/read.go
+++ b/example2/read/read.go
@@ -3,8 +3,8 @@ package main
 import (
 	"context"
 
-	"github.com/go-redis/redis/v9"
 	"github.com/kkkbird/qdelayed"
+	"github.com/redis/go-redis/v9"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dirkm/qdelayed
+module github.com/kkkbird/qdelayed
 
 go 1.17
 
@@ -34,4 +34,3 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/kkkbird/qdelayed => ./

--- a/go.mod
+++ b/go.mod
@@ -3,16 +3,15 @@ module github.com/kkkbird/qdelayed
 go 1.17
 
 require (
-	github.com/go-redis/redis/v8 v8.11.3
-	github.com/go-redis/redis/v9 v9.0.0-rc.1
+	github.com/redis/go-redis/v9 v9.0.2
 	github.com/kkkbird/quuid v0.0.0-20210927080042-a29962956d1c
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/viper v1.9.0
-	github.com/stretchr/testify v1.8.0
+	github.com/stretchr/testify v1.8.1
 )
 
 require (
-	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
@@ -21,6 +20,7 @@ require (
 	github.com/mitchellh/mapstructure v1.4.2 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/redis/go-redis/v9 v9.0.2 // indirect
 	github.com/spf13/afero v1.6.0 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
@@ -32,4 +32,3 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,15 @@
-module github.com/kkkbird/qdelayed
+module github.com/dirkm/qdelayed
 
 go 1.17
 
 require (
 	github.com/go-redis/redis/v8 v8.11.3
+	github.com/go-redis/redis/v9 v9.0.0-rc.1
+	github.com/kkkbird/qdelayed v0.0.0-20210927080705-29957531a7e7
 	github.com/kkkbird/quuid v0.0.0-20210927080042-a29962956d1c
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/viper v1.9.0
-	github.com/stretchr/testify v1.7.0
+	github.com/stretchr/testify v1.8.0
 )
 
 require (
@@ -25,9 +27,11 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
-	golang.org/x/sys v0.0.0-20210927052749-1cf2251ac284 // indirect
+	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/ini.v1 v1.63.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/kkkbird/qdelayed => ./

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.17
 require (
 	github.com/go-redis/redis/v8 v8.11.3
 	github.com/go-redis/redis/v9 v9.0.0-rc.1
-	github.com/kkkbird/qdelayed v0.0.0-20210927080705-29957531a7e7
 	github.com/kkkbird/quuid v0.0.0-20210927080042-a29962956d1c
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/viper v1.9.0


### PR DESCRIPTION
I upgraded to "github.com/go-redis/redis/v9", due to a bug with v8 which bit me in another part of my project.

redisclient v9 is not released yet, but this might help you (trivially) with the upgrade, later.